### PR TITLE
Fix: deselect children on collapse of parent

### DIFF
--- a/Source/OctaneGUI/Controls/Tree.cpp
+++ b/Source/OctaneGUI/Controls/Tree.cpp
@@ -708,7 +708,7 @@ bool Tree::IsHidden(const std::shared_ptr<TreeItem>& Item) const
         return false;
     }
 
-    if (m_List->HasControl(Item))
+    if (m_List->HasControlRecurse(Item))
     {
         return !m_Expand;
     }


### PR DESCRIPTION
Fix for https://github.com/mdavisprog/OctaneGUI/issues/6