### PR TITLE
Spinner, new Orientation key

### DIFF
--- a/Apps/Overview/Overview.json
+++ b/Apps/Overview/Overview.json
@@ -50,9 +50,12 @@
                                     {"Type": "GroupBox", "Text": "Max Characters", "Expand": "Width", "Controls": [
                                         {"Type": "TextInput", "MaxCharacters": 4, "Expand": "Width", "NumbersOnly": true, "Text": {"Text": "3.1415926"}}
                                     ]},
-                                    {"Type": "GroupBox", "Text": "Spinner", "Expand": "Width", "Controls": [
+                                    {"Type": "GroupBox", "Text": "Spinner Horizontal", "Expand": "Width", "Controls": [
                                         {"Type": "Spinner", "Expand": "Width", "Value": 36, "Range": {"Min":-20, "Max": 20} }
                                     ]},
+                                    {"Type": "GroupBox", "Text": "Spinner Vertical", "Expand": "Width", "Controls": [
+                                        {"Type": "Spinner", "Expand": "Width", "Value": 5, "Orientation": "Vertical"}
+                                    ]}
                                 ]},
                                 {"Type": "Separator", "Orientation": "Vertical"},
                                 {"Type": "GroupBox", "Text": "Multi line text input", "Controls": [

--- a/Source/OctaneGUI/Controls/Spinner.cpp
+++ b/Source/OctaneGUI/Controls/Spinner.cpp
@@ -43,31 +43,6 @@ Spinner::Spinner(Window* InWindow)
 
     m_Input = AddControl<TextInput>();
     m_Input->SetReadOnly(true);
-
-    m_DecrementButton = AddControl<ImageButton>();
-    m_IncrementButton = AddControl<ImageButton>();
-
-    m_DecrementButton->SetTexture(InWindow->GetIcons()->GetTexture())
-        .SetUVs(InWindow->GetIcons()->GetUVs(Icons::Type::ArrowLeft))
-        .SetOnPressed([this](const Button&)
-            {
-                SetValue(m_Value - 1);
-            });
-
-    m_IncrementButton->SetTexture(InWindow->GetIcons()->GetTexture())
-        .SetUVs(InWindow->GetIcons()->GetUVs(Icons::Type::ArrowRight))
-        .SetOnPressed([this](const Button&)
-            {
-                SetValue(m_Value + 1);
-            });
-
-    Vector2 ButtonSize = Vector2(m_IncrementButton->GetSize().X * 0.75f, m_Input->GetSize().Y);
-
-    m_DecrementButton->SetSize(ButtonSize);
-    m_IncrementButton->SetSize(ButtonSize);
-
-    // Setup the color to use by default for the image button.
-    OnThemeLoaded();
 }
 
 Spinner& Spinner::SetValue(const int32_t Value)
@@ -91,6 +66,51 @@ void Spinner::OnLoad(const Json& Root)
     m_Max = Root["Range"]["Max"].Number();
 
     SetValue(static_cast<int32_t>(Root["Value"].Number()));
+    
+    Icons::Type IncrementIcon;
+    Icons::Type DecrementIcon;
+    Vector2 ButtonSize;
+    
+    if (Root.Contains("Orientation") && strcmp(Root["Orientation"].String(),"Vertical") == 0)
+    {
+        m_ButtonOrientation = Orientation::Vertical;
+        
+        m_ButtonContainer = AddControl<VerticalContainer>();
+        std::static_pointer_cast<VerticalContainer>(m_ButtonContainer)->SetSpacing(Vector2{0.0f,0.0f});
+        
+        IncrementIcon = Icons::Type::ArrowUp;
+        DecrementIcon = Icons::Type::ArrowDown;
+        ButtonSize = Vector2(m_Input->GetSize() * Vector2{0.50f, 0.50f} );
+        
+        m_IncrementButton = m_ButtonContainer->AddControl<ImageButton>();
+        m_DecrementButton = m_ButtonContainer->AddControl<ImageButton>();
+    }
+    else
+    {
+        m_ButtonContainer = AddControl<HorizontalContainer>();
+        std::static_pointer_cast<HorizontalContainer>(m_ButtonContainer)->SetSpacing(Vector2{0.0f,0.0f});
+        
+        IncrementIcon = Icons::Type::ArrowRight;
+        DecrementIcon = Icons::Type::ArrowLeft;
+        ButtonSize = Vector2(m_Input->GetSize() * Vector2{0.25f, 1.00f} );
+        
+        m_DecrementButton = m_ButtonContainer->AddControl<ImageButton>();
+        m_IncrementButton = m_ButtonContainer->AddControl<ImageButton>();
+    }
+
+    m_IncrementButton->SetTexture(GetWindow()->GetIcons()->GetTexture())
+        .SetUVs(GetWindow()->GetIcons()->GetUVs(IncrementIcon));
+    m_DecrementButton->SetTexture(GetWindow()->GetIcons()->GetTexture())
+        .SetUVs(GetWindow()->GetIcons()->GetUVs(DecrementIcon));
+    
+    m_DecrementButton->SetSize(ButtonSize);
+    m_IncrementButton->SetSize(ButtonSize);
+    
+    m_DecrementButton->SetOnPressed([this](const Button&) { SetValue(m_Value - 1); });
+    m_IncrementButton->SetOnPressed([this](const Button&) { SetValue(m_Value + 1); });
+    
+    // Setup the color to use by default for the image button.
+    OnThemeLoaded();
 }
 
 void Spinner::OnThemeLoaded()

--- a/Source/OctaneGUI/Controls/Spinner.h
+++ b/Source/OctaneGUI/Controls/Spinner.h
@@ -27,6 +27,7 @@ SOFTWARE.
 #pragma once
 
 #include "HorizontalContainer.h"
+#include "VerticalContainer.h"
 
 namespace OctaneGUI
 {
@@ -62,10 +63,14 @@ private:
     int32_t m_Min { 0 };
     int32_t m_Max { 0 };
     int32_t m_Value { 0 };
+    
+    Orientation m_ButtonOrientation { Orientation::Horizontal };
 
     std::shared_ptr<TextInput> m_Input { nullptr };
     std::shared_ptr<ImageButton> m_DecrementButton { nullptr };
     std::shared_ptr<ImageButton> m_IncrementButton { nullptr };
+    
+    std::shared_ptr<Container> m_ButtonContainer { nullptr };
 
 };
 


### PR DESCRIPTION
Addition of an `Orientation` key for Spinner to allow for vertical up/down, still defaults to `Horizontal` as per https://github.com/mdavisprog/OctaneGUI/commit/4483bffe1b0e1d667dbd6b004bac928f079ae107

<img width="189" alt="Screenshot 2022-08-20 at 20 09 55" src="https://user-images.githubusercontent.com/56652672/185762737-bbd01a65-63e6-4c57-8543-010c28f052d3.png">
